### PR TITLE
Support the `&&` style syntax in `safeXml`

### DIFF
--- a/src/safeXml.test.ts
+++ b/src/safeXml.test.ts
@@ -36,4 +36,11 @@ describe("safeXml", () => {
     const output = safeXml`<name>${["this", undefined, " is", null, " awesome!"]}</name>`;
     expect(output).toEqual("<name>this is awesome!</name>");
   });
+
+  test("valid with the common '&&' syntax", () => {
+    const truthyOutput = safeXml`<name>${true && "this is awesome!"}</name>`;
+    expect(truthyOutput).toEqual("<name>this is awesome!</name>");
+    const falseyOutput = safeXml`<name>${false && "this is awesome!"}</name>`;
+    expect(falseyOutput).toEqual("<name></name>");
+  });
 });

--- a/src/safeXml.ts
+++ b/src/safeXml.ts
@@ -7,11 +7,11 @@ import { xml2js } from "xml-js";
  */
 export function safeXml(
   templateStrings: TemplateStringsArray,
-  ...templateValues: (undefined | null | string | number | (undefined | null | string | number)[])[]
+  ...templateValues: (undefined | null | false | string | number | (undefined | null | false | string | number)[])[]
 ) {
   let xml = "";
   for (let i = 0; i < templateStrings.length; i++) {
-    if (templateValues[i] !== undefined && templateValues[i] !== null) {
+    if (templateValues[i] !== undefined && templateValues[i] !== null && templateValues[i] !== false) {
       const value = templateValues[i];
       const xmlPart = Array.isArray(value) ? value.join("") : value;
       xml += `${templateStrings[i]!}${xmlPart}`;


### PR DESCRIPTION
The `safeXml` method now supports

```ts
const truthyOutput = safeXml`<name>${true && "this is awesome!"}</name>`;
expect(truthyOutput).toEqual("<name>this is awesome!</name>");
const falseyOutput = safeXml`<name>${false && "this is awesome!"}</name>`;
expect(falseyOutput).toEqual("<name></name>");
```